### PR TITLE
Minor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ We follow [Semantic Versions](https://semver.org/).
 
 - Confirm support for python 3.13
 - Add `get_s3_client` shortcut for `django` module
+- Make `pytest` plugin auto-detect if it's `django` project, so that it could
+use `django` storage for `s3` setup
 
 ## 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ We follow [Semantic Versions](https://semver.org/).
 ## Unreleased
 
 - Confirm support for python 3.13
+- Add `get_s3_client` shortcut for `django` module
 
 ## 0.2.1
 

--- a/README.md
+++ b/README.md
@@ -132,23 +132,12 @@ path(
 Just add this to core `conftest.py` file
 
 ```python
-from django.core.files.storage import default_storage
-import mypy_boto3_s3
 import pytest
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _adjust_s3_bucket(
-    s3_bucket: str,
-) -> None:
+def _adjust_s3_bucket(django_adjust_s3_bucket: None) -> None:
     """Set bucket to a test one."""
-    default_storage.bucket_name = s3_bucket
-
-
-@pytest.fixture(scope="session")
-def boto3_resource() -> mypy_boto3_s3.S3ServiceResource:
-    """Prepare boto3 resource."""
-    return default_storage.connection
 ```
 
 ### Note about signature version

--- a/example/app/models.py
+++ b/example/app/models.py
@@ -53,7 +53,7 @@ class ModelWithFiles(models.Model):
         null=True,
         s3_config=saritasa_s3_tools.S3FileTypeConfig(  # pyright: ignore
             name="django-anon-files",
-            key=saritasa_s3_tools.keys.WithPrefixUUIDFolder(
+            key=saritasa_s3_tools.keys.WithPrefixUUIDFileName(
                 "django-anon-files",
             ),
         ),

--- a/saritasa_s3_tools/django/__init__.py
+++ b/saritasa_s3_tools/django/__init__.py
@@ -6,4 +6,5 @@ from .serializers import (
     S3RequestParamsSerializer,
     S3UploadSerializer,
 )
+from .shortcuts import get_s3_client
 from .views import S3GetParamsView

--- a/saritasa_s3_tools/django/shortcuts.py
+++ b/saritasa_s3_tools/django/shortcuts.py
@@ -1,0 +1,11 @@
+from django.core.files.storage import default_storage
+
+from .. import client
+
+
+def get_s3_client() -> client.S3Client:
+    """Get s3 client for working with s3."""
+    return client.S3Client(
+        boto3_client=default_storage.connection.meta.client,  # type: ignore
+        default_bucket=default_storage.bucket_name,  # type: ignore
+    )

--- a/saritasa_s3_tools/django/shortcuts.py
+++ b/saritasa_s3_tools/django/shortcuts.py
@@ -4,7 +4,7 @@ from .. import client
 
 
 def get_s3_client() -> client.S3Client:
-    """Get s3 client for working with s3."""
+    """Get s3 client based on Django default storage."""
     return client.S3Client(
         boto3_client=default_storage.connection.meta.client,  # type: ignore
         default_bucket=default_storage.bucket_name,  # type: ignore

--- a/saritasa_s3_tools/django/views.py
+++ b/saritasa_s3_tools/django/views.py
@@ -2,7 +2,6 @@ import contextlib
 import dataclasses
 import typing
 
-from django.core.files.storage import default_storage
 from rest_framework import (
     decorators,
     permissions,
@@ -12,10 +11,8 @@ from rest_framework import (
 )
 from rest_framework.request import Request
 
-import mypy_boto3_s3
-
 from .. import client
-from . import serializers
+from . import serializers, shortcuts
 
 
 class S3GetParamsView(viewsets.GenericViewSet):
@@ -63,18 +60,9 @@ class S3GetParamsView(viewsets.GenericViewSet):
             ).data,
         )
 
-    def get_boto3_client(self) -> mypy_boto3_s3.S3Client:
-        """Get s3 client for params generation."""
-        return default_storage.connection.meta.client  # type: ignore
-
     def get_s3_client(self) -> client.S3Client:
         """Get s3 client for params generation."""
-        return client.S3Client(
-            boto3_client=self.get_boto3_client(),
-            default_bucket=(
-                default_storage.bucket_name  # type: ignore
-            ),
-        )
+        return shortcuts.get_s3_client()
 
     def get_extra_meta_data(
         self,

--- a/tests/test_boto3_resource_from_config.py
+++ b/tests/test_boto3_resource_from_config.py
@@ -1,0 +1,9 @@
+import mypy_boto3_s3
+
+
+def test_fixture(
+    boto3_resource_from_config: mypy_boto3_s3.S3ServiceResource,
+    s3_bucket_name: str,
+) -> None:
+    """Test that alternative fixture for s3 resource is working."""
+    boto3_resource_from_config.Bucket(s3_bucket_name).objects.all()

--- a/tests/test_django/conftest.py
+++ b/tests/test_django/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import pytest_django
-from django.core.files.storage import default_storage
 from django.urls import reverse_lazy
 from rest_framework import test
 
@@ -18,11 +17,8 @@ def _enable_db_access_for_all_tests(django_db_setup, db) -> None:  # noqa: ANN00
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _adjust_s3_bucket(
-    s3_bucket: str,
-) -> None:
+def _adjust_s3_bucket(django_adjust_s3_bucket: None) -> None:
     """Set bucket to a test one."""
-    default_storage.bucket_name = s3_bucket  # type: ignore
 
 
 @pytest.fixture


### PR DESCRIPTION
- Add `get_s3_client` shortcut for `django` module
- Make `pytest` plugin auto-detect if it's `django` project, so that it could
use `django` storage for `s3` setup