### PR TITLE
Extend pytest plugin and client with new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ We follow [Semantic Versions](https://semver.org/).
 
 - Fix `AttributeError` when accessing django `list-configs` API using
   `BrowsableAPIRenderer`
+- Extend pytest plugin to support bucket policy and delete on teardown options
+- Add `generate_direct_url` method to client for generating urls for
+  direct file access without auth query params
 
 ## 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ customization, None by default.
 - `boto3_client`- Returns s3 client or in typing `mypy_boto3_s3.S3Client`
 - `s3_bucket_name` - Name of bucket for testing, default: `saritasa-s3-tools`
 or `s3_bucket_name` from ini file.
+- `s3_bucket_policy` - Policy for bucket, default is empty, you can set it up
+to test different permissions.
+- `s3_bucket_delete_on_teardown` - If bucket should be deleted on teardown,
+by default `False` since on new test run bucket is recreated
 - `s3_bucket_cleaner` - Returns function which cleans all files from bucket
 - `s3_bucket_factory` - Returns manager which creates bucket, and when it's no
 longer needed deletes it

--- a/saritasa_s3_tools/client.py
+++ b/saritasa_s3_tools/client.py
@@ -254,7 +254,7 @@ class S3Client:
         self,
         key: str,
         bucket: str = "",
-        expiration: int = 0,
+        expiration: int | None = None,
     ) -> str:
         """Generate url for viewing/downloading file."""
         return self.boto3_client.generate_presigned_url(
@@ -263,8 +263,25 @@ class S3Client:
                 "Bucket": bucket or self.default_bucket,
                 "Key": key,
             },
-            ExpiresIn=expiration or self.default_download_expiration,
+            ExpiresIn=expiration
+            if expiration is not None
+            else self.default_download_expiration,
         )
+
+    def generate_direct_url(
+        self,
+        key: str,
+        bucket: str = "",
+    ) -> str:
+        """Generate direct url for viewing/downloading file."""
+        return self.boto3_client.generate_presigned_url(
+            ClientMethod="get_object",
+            Params={
+                "Bucket": bucket or self.default_bucket,
+                "Key": key,
+            },
+            ExpiresIn=0,
+        ).split("?")[0]
 
     def get_file_metadata(
         self,

--- a/saritasa_s3_tools/testing/plugin.py
+++ b/saritasa_s3_tools/testing/plugin.py
@@ -1,5 +1,6 @@
 import collections.abc
 import contextlib
+import json
 import typing
 
 import pytest
@@ -184,6 +185,18 @@ def s3_bucket_name(
 
 
 @pytest.fixture(scope="session")
+def s3_bucket_policy() -> dict[str, typing.Any]:
+    """Get the policy of s3 bucket."""
+    return {}
+
+
+@pytest.fixture(scope="session")
+def s3_bucket_delete_on_teardown() -> bool:
+    """Delete bucket on teardown or not."""
+    return False
+
+
+@pytest.fixture(scope="session")
 def s3_bucket_cleaner(
     boto3_resource: mypy_boto3_s3.ServiceResource,
 ) -> collections.abc.Callable[[str], None]:
@@ -201,7 +214,11 @@ def s3_bucket_factory(
     s3_region: str,
     s3_bucket_cleaner: collections.abc.Callable[[str], None],
 ) -> collections.abc.Callable[
-    [str],
+    [
+        str,
+        dict[str, typing.Any],
+        bool,
+    ],
     contextlib._GeneratorContextManager[
         mypy_boto3_s3.type_defs.CreateBucketOutputTypeDef
     ],
@@ -211,6 +228,8 @@ def s3_bucket_factory(
     @contextlib.contextmanager
     def _create(
         bucket: str,
+        policy: dict[str, typing.Any],
+        delete_on_teardown: bool,
     ) -> collections.abc.Generator[
         mypy_boto3_s3.type_defs.CreateBucketOutputTypeDef
     ]:
@@ -218,14 +237,21 @@ def s3_bucket_factory(
             boto3_client.head_bucket(Bucket=bucket)
             s3_bucket_cleaner(bucket)  # pragma: no cover
             boto3_client.delete_bucket(Bucket=bucket)  # pragma: no cover
-        yield boto3_client.create_bucket(
+        response = boto3_client.create_bucket(
             Bucket=bucket,
             CreateBucketConfiguration={
                 "LocationConstraint": s3_region,  # type: ignore
             },
         )
-        s3_bucket_cleaner(bucket)
-        boto3_client.delete_bucket(Bucket=bucket)
+        if policy:
+            boto3_client.put_bucket_policy(
+                Bucket=bucket,
+                Policy=json.dumps(policy),
+            )
+        yield response
+        if delete_on_teardown:
+            s3_bucket_cleaner(bucket)
+            boto3_client.delete_bucket(Bucket=bucket)
 
     return _create
 
@@ -233,15 +259,21 @@ def s3_bucket_factory(
 @pytest.fixture(scope="session")
 def s3_bucket(
     s3_bucket_factory: collections.abc.Callable[
-        [str],
+        [str, dict[str, typing.Any], bool],
         contextlib._GeneratorContextManager[
             mypy_boto3_s3.type_defs.CreateBucketOutputTypeDef
         ],
     ],
     s3_bucket_name: str,
+    s3_bucket_policy: dict[str, typing.Any],
+    s3_bucket_delete_on_teardown: bool,
 ) -> collections.abc.Generator[str]:
     """Create s3 bucket."""
-    with s3_bucket_factory(s3_bucket_name) as _:
+    with s3_bucket_factory(
+        s3_bucket_name,
+        s3_bucket_policy,
+        s3_bucket_delete_on_teardown,
+    ) as _:
         yield s3_bucket_name
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import typing
+
 import pytest
 
 import saritasa_s3_tools
@@ -19,3 +21,30 @@ saritasa_s3_tools.S3FileTypeConfig(
 def anyio_backend() -> str:
     """Specify async backend."""
     return "asyncio"
+
+
+@pytest.fixture(scope="session")
+def s3_bucket_policy(
+    s3_bucket_name: str,
+) -> dict[str, typing.Any]:
+    """Get the policy of s3 bucket."""
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "PublicReadAvatars",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": (
+                    f"arn:aws:s3:::{s3_bucket_name}/django-anon-files/*"
+                ),
+            },
+        ],
+    }
+
+
+@pytest.fixture(scope="session")
+def s3_bucket_delete_on_teardown() -> bool:
+    """Delete bucket on teardown."""
+    return True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -90,6 +90,22 @@ def test_presigned_url(s3_client: saritasa_s3_tools.S3Client) -> None:
     assert response.is_success, response.content
 
 
+def test_direct_url(s3_client: saritasa_s3_tools.S3Client) -> None:
+    """Test file generation of direct url."""
+    with pathlib.Path(__file__).open("rb") as upload_file:
+        upload_key = s3_client.upload_file(
+            filename=pathlib.Path(__file__).name,
+            config=saritasa_s3_tools.S3FileTypeConfig.configs[
+                "django-anon-files"
+            ],
+            file_obj=upload_file,
+        )
+    direct_url = s3_client.generate_direct_url(key=upload_key)
+    with httpx.Client() as client:
+        response = client.get(direct_url)
+    assert response.is_success, response.content
+
+
 def test_upload_expiration(s3_client: saritasa_s3_tools.S3Client) -> None:
     """Test file upload expiration."""
     s3_params = s3_client.generate_params(


### PR DESCRIPTION
- Extend pytest plugin to support bucket policy and delete on teardown options
- Add `generate_direct_url` method to client for generating URLs for direct file access without auth query params
